### PR TITLE
Tried to make it so that aif and em are interoperable. 

### DIFF
--- a/ethicml/__init__.py
+++ b/ethicml/__init__.py
@@ -23,6 +23,7 @@ from .algorithms.preprocess.pre_algorithm import *
 from .algorithms.preprocess.upsampler import *
 from .algorithms.preprocess.vfae import *
 from .algorithms.preprocess.zemel import *
+from .algorithms.preprocess.zemel_aif import *
 from .common import *
 from .data.dataset import *
 from .data.load import *

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -32,15 +32,14 @@ class PreAlgorithm(Algorithm):
         self._out_size = out_size
 
     @abstractmethod
-    def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
+    def fit(self, train: DataTuple) -> PreAlgorithm:
         """Generate fair features with the given data.
 
         Args:
             train: training data
-            test: test data
 
         Returns:
-            a tuple of the pre-processed training data and the test data
+            a trained model
         """
 
     @abstractmethod
@@ -48,11 +47,10 @@ class PreAlgorithm(Algorithm):
         """Generate fair features with the given data.
 
         Args:
-            train: training data
             test: test data
 
         Returns:
-            a tuple of the pre-processed training data and the test data
+            transformed test data
         """
 
     @abstractmethod

--- a/ethicml/algorithms/preprocess/zemel_aif.py
+++ b/ethicml/algorithms/preprocess/zemel_aif.py
@@ -1,0 +1,138 @@
+"""Zemel's Learned Fair Representations."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple, Type, TypeVar, Union
+
+import aif360
+import numpy as np
+import pandas as pd
+from aif360.algorithms.preprocessing import LFR
+from aif360.datasets import StandardDataset
+from ranzen import implements
+
+from ethicml.utility import DataTuple, TestTuple
+
+from .pre_algorithm import PreAlgorithm
+
+T = TypeVar("T", DataTuple, TestTuple)
+
+__all__ = ["ZemelAif"]
+
+
+class AifPreAlgorithm(PreAlgorithm):
+    def em_to_aif360(self, data: DataTuple) -> aif360.datasets.StandardDataset:
+        self.target_cols = data.y.columns
+        self.sens_cols = data.s.columns
+
+        df = pd.concat([data.x, data.s, data.y], axis="columns")
+
+        return StandardDataset(
+            df=df,
+            label_name=data.y.columns[0],
+            favorable_classes=lambda x: x > 0,
+            protected_attribute_names=data.s.columns,
+            privileged_classes=[lambda x: x == 1],
+            categorical_features=[],
+        )
+
+    def aif360_to_em(self, data: StandardDataset) -> DataTuple:
+        sens_feats = np.reshape(
+            data.protected_attributes[
+                :, data.protected_attribute_names.index(self.alg.protected_attribute_name)
+            ],
+            [-1, 1],
+        )
+        sens_feats = pd.DataFrame(sens_feats, columns=[self.sens_cols])
+
+        target_feats = pd.DataFrame(data.labels, columns=[self.target_cols])
+
+        return DataTuple(x=data.features, s=sens_feats, y=target_feats)
+
+    def __init__(
+        self,
+        aif360_algo: Type[aif360.Transformer],
+        fit_extra_args: Dict[str, Any],
+        name: str,
+        seed: int,
+        init_extra_args: Dict[str, Any],
+    ):
+        super().__init__(name, seed, out_size=None)
+        self._aif360_algo = aif360_algo
+        self._fit_extra_args = fit_extra_args
+        self._init_args = init_extra_args
+
+    @implements(PreAlgorithm)
+    def fit(self, train_data: DataTuple) -> AifPreAlgorithm:
+        unprivileged_group = [{train_data.s.columns[0]: 0}]
+        privileged_group = [{train_data.s.columns[0]: 1}]
+
+        self.alg = self._aif360_algo(
+            privileged_groups=privileged_group,
+            unprivileged_groups=unprivileged_group,
+            **self._init_args,
+        )
+
+        aif360_dataset = self.em_to_aif360(train_data)
+        self.alg = self.alg.fit(aif360_dataset, **self._fit_extra_args)
+        return self
+
+    @implements(PreAlgorithm)
+    def transform(self, data: T) -> T:
+        aif360_dataset = self.em_to_aif360(data)
+        result = self.alg.predict(aif360_dataset)
+        return self.aif360_to_em(result)
+
+    @implements(PreAlgorithm)
+    def run(self, train: DataTuple, test: TestTuple) -> Tuple[DataTuple, TestTuple]:
+        self._out_size = train.x.shape[1]
+        unprivileged_group = [{train.s.columns[0]: 0}]
+        privileged_group = [{train.s.columns[0]: 1}]
+
+        self.alg = self._aif360_algo(
+            privileged_groups=privileged_group,
+            unprivileged_groups=unprivileged_group,
+            **self._init_args,
+        )
+
+        train = self.em_to_aif360(train)
+        self.alg = self.alg.fit(train, **self._fit_extra_args)
+        test = self.em_to_aif360(test)
+        train = self.alg.transform(train)
+        test = self.alg.transform(test)
+        return self.aif360_to_em(train), self.aif360_to_em(test)
+
+
+class ZemelAif(AifPreAlgorithm):
+    """AIF360 implementation of Zemel's LFR."""
+
+    def __init__(
+        self,
+        dir: Union[str, Path],
+        threshold: float = 0.5,
+        clusters: int = 2,
+        Ax: float = 0.01,
+        Ay: float = 0.1,
+        Az: float = 0.5,
+        max_iter: int = 5_000,
+        maxfun: int = 5_000,
+        epsilon: float = 1e-5,
+        seed: int = 888,
+    ) -> None:
+        super().__init__(
+            name="Zemel",
+            seed=seed,
+            aif360_algo=LFR,
+            fit_extra_args={},
+            init_extra_args={
+                "k": clusters,
+                "Ax": Ax,
+                "Ay": Ay,
+                "Az": Az,
+                # "epsilon": epsilon,
+                "verbose": 0,
+                # "max_iter": max_iter,
+                # "maxfun": maxfun,
+                # "threshold": threshold,
+            },
+        )

--- a/tests/models_test/preprocess_test/models_preprocessing_test.py
+++ b/tests/models_test/preprocess_test/models_preprocessing_test.py
@@ -22,6 +22,7 @@ from ethicml import (
     TrainTestPair,
     Upsampler,
     Zemel,
+    ZemelAif,
 )
 
 
@@ -34,6 +35,13 @@ class PreprocessTest(NamedTuple):
 
 
 METHOD_LIST = [
+    PreprocessTest(
+        model=ZemelAif(
+            dir='/tmp',
+        ),
+        name="Zemel",
+        num_pos=5,
+    ),
     PreprocessTest(
         model=VFAE(
             dir='/tmp',


### PR DESCRIPTION
Turns out that it's totally possible to switch between EM and AIF datasets, providing that you do a lot of the definitions at runtime.
The problem is that there are some fundamental design differences, and I don't know how to get past them, so putting this here so that everyone can see what I've done.