### PR TITLE
make metrics part of evaluation run in parallel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     rev: 6.1.1  # pick a git hash / tag to point to
     hooks:
       - id: pydocstyle
+        additional_dependencies: ['.[toml]']
         args:
           - --convention=google
           - --add-ignore=D105,D107

--- a/tests/run_algorithm_test.py
+++ b/tests/run_algorithm_test.py
@@ -25,7 +25,6 @@ def test_can_load_test_data(toy_train_test: em.TrainTestPair):
 
 def test_run_parallel(toy_train_val: em.TrainValPair):
     """Test run parallel."""
-
     data0 = toy_train_val
     data1 = toy_train_val
     result = em.run_in_parallel(
@@ -196,7 +195,7 @@ def test_run_alg_suite():
     for file in file_names:
         written_file = pd.read_csv(Path(f"./results/{file}"))
         assert (written_file["seed"][0], written_file["seed"][1]) == (0, 0)
-        assert written_file.shape == (2, 19)
+        assert written_file.shape == (2, 20)
 
     reloaded = em.load_results("Adult Race-Binary", "Upsample uniform", "pytest")
     assert reloaded is not None

--- a/tests/visualisation_test.py
+++ b/tests/visualisation_test.py
@@ -89,11 +89,11 @@ def test_plot_evals():
 
     # plot with metrics
     figs_and_plots = plot_results(results, Accuracy(), ProbPos())
-    # num(datasets) * num(preprocess) * num(accuracy combinations) * num(prop_pos combinations)
-    assert len(figs_and_plots) == 2 * 2 * 1 * 2
+    # num(datasets) * num(preprocess) * num(accuracy in results) * num(prob_pos in results)
+    assert len(figs_and_plots) == 1 * 2 * 1 * 2
 
     # plot with column names
-    figs_and_plots = plot_results(results, "Accuracy", "prob_pos_sensitive-attr_0")
+    figs_and_plots = plot_results(results, "Accuracy", "prob_pos_S_0")
     assert len(figs_and_plots) == 1 * 2 * 1 * 1
 
     with pytest.raises(ValueError, match='No matching columns found for Metric "NMI preds and s".'):


### PR DESCRIPTION
The obvious question, is why? Metrics are fast enough, what is there to be gained from parallelising this. The reason that I've done this is because there are some metrics will take longer (e.g. [this](https://github.com/yromano/fair_dummies/blob/master/fair_dummies/utility_functions.py#L347) trains a NN as part of the metric).