### PR TITLE
Change dependencies for building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "autodocsumm",
     "nbsphinx",
-    'IPython.sphinxext.ipython_console_highlighting',
+    "ipython_pygments",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ typing_extensions
 furo
 toml
 nbsphinx @ git+https://github.com/thomkeh/nbsphinx.git@e69b06f131428c595361117754b3b0fbc385d43a
-ipython
+ipython-pygments


### PR DESCRIPTION
Previously, ipython was a dependency, but that was overkill.
