### PR TITLE
Use a new caching strategy for the CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -126,6 +126,15 @@ jobs:
           key: poetry-cache-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.POETRY_VERSION }}
 
       #----------------------------------------------
+      # cache the directory where pip caches packages
+      #----------------------------------------------
+      - name: Cache Pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ runner.os }}-${{ env.PYTHON_VERSION }}
+
+      #----------------------------------------------
       #  ---------  install dependencies  --------
       #----------------------------------------------
       - name: Install dependencies

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -112,23 +112,23 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Set ENV VARS
+        run: |
+          echo "POETRY_VERSION=$(poetry --version)" >> $GITHUB_ENV
 
       #----------------------------------------------
-      #       load cached venv if cache exists
+      # cache the directory where poetry caches packages
       #----------------------------------------------
-      - name: Set up Poetry cache for Python dependencies
-        id: cached-poetry-dependencies
-        # uses: actions/cache@v2
-        uses: pat-s/always-upload-cache@v2
+      - name: Cache Poetry cache
+        uses: actions/cache@v2
         with:
-          path: .venv
-          key: venvEM2-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          path: ~/.cache/pypoetry
+          key: poetry-cache-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.POETRY_VERSION }}
 
       #----------------------------------------------
-      # install dependencies if cache does not exist
+      #  ---------  install dependencies  --------
       #----------------------------------------------
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           poetry install -E ci --no-interaction --no-root
           poetry run pip install torch --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Instead of caching the whole python venv, we'll only cache poetry's cache. The main advantage is that this won't be so quickly invalidated.